### PR TITLE
Remove apk update prior to using apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@
 
 FROM python:3.5-alpine
 
-RUN apk update && \
-    apk add --no-cache python3-dev gcc git g++ make libvirt-dev
+RUN apk add --no-cache python3-dev gcc git g++ make libvirt-dev
 
 ENV VIRTUALPDU_RELEASE 0.3.5
 RUN pip install --no-cache-dir "virtualpdu==$VIRTUALPDU_RELEASE"


### PR DESCRIPTION
Currently, apk update runs prior to installing packages. With the
--no-cache option, this is redundant [0].

This commit removes this unnecessary command.

[0] https://github.com/gliderlabs/docker-alpine/blob/master/docs/usage.md