### PR TITLE
Explain how to use prebuilt images

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,32 @@ the ability simulates the following PDUs:
  - [Baytech MRP27 PDU](https://github.com/openstack/virtualpdu/blob/master/virtualpdu/pdu/baytech_mrp27.py)
 
 
-Usage
------
+Quick start
+-----------
+
+### Using Docker ###
+
+#### From source ####
+
+        docker build -t virtualpdu-container .
+        docker run virtualpdu-container
+
+#### From Docker Hub ####
+
+        docker run internap/virtualpdu-container:latest
+
+
+### Using Docker-Compose ###
+
+#### From source ####
+        docker-compose up --build
+        
+#### From Docker Hub ####
+	    docker-compose -f docker-compose.yml -f docker-compose.prebuilt.yml up -d
+
+        
+Configuration
+-------------
 
 To configure the service, some environmental variables must be
 set.  It is possible to pass a complete configuration to simulate

--- a/README.md
+++ b/README.md
@@ -18,21 +18,23 @@ Quick start
 
 #### From source ####
 
-        docker build -t virtualpdu-container .
-        docker run virtualpdu-container
+    docker build -t virtualpdu-container .
+    docker run virtualpdu-container
 
 #### From Docker Hub ####
 
-        docker run internap/virtualpdu-container:latest
+    docker run internap/virtualpdu-container:latest
 
 
 ### Using Docker-Compose ###
 
 #### From source ####
-        docker-compose up --build
+
+    docker-compose up --build
         
 #### From Docker Hub ####
-	    docker-compose -f docker-compose.yml -f docker-compose.prebuilt.yml up -d
+
+    docker-compose -f docker-compose.yml -f docker-compose.prebuilt.yml up -d
 
         
 Configuration

--- a/README.md
+++ b/README.md
@@ -18,23 +18,23 @@ Quick start
 
 #### From source ####
 
-    docker build -t virtualpdu-container .
-    docker run virtualpdu-container
+    $ docker build -t virtualpdu-container .
+    $ docker run virtualpdu-container
 
 #### From Docker Hub ####
 
-    docker run internap/virtualpdu-container:latest
+    $ docker run internap/virtualpdu-container:latest
 
 
 ### Using Docker-Compose ###
 
 #### From source ####
 
-    docker-compose up --build
+    $ docker-compose up --build
         
 #### From Docker Hub ####
 
-    docker-compose -f docker-compose.yml -f docker-compose.prebuilt.yml up -d
+    $ docker-compose -f docker-compose.yml -f docker-compose.prebuilt.yml up -d
 
         
 Configuration

--- a/docker-compose.prebuilt.yml
+++ b/docker-compose.prebuilt.yml
@@ -1,0 +1,10 @@
+---
+version: '2'
+
+services:
+  virtualpdu_1:
+    image: internap/virtualpdu-container:latest
+  virtualpdu_2:
+    image: internap/virtualpdu-container:latest
+  virtualpdu_3:
+    image: internap/virtualpdu-container:latest


### PR DESCRIPTION
Currently, prebuilt images are published, but we have no instructions
for using them.

This commit adds instructions and a minimal docker-compose file to use
Docker Hub images instead of building from source.